### PR TITLE
Replace JCenter repo with Maven Central

### DIFF
--- a/widen-simple-one-way-sso-java/build.gradle
+++ b/widen-simple-one-way-sso-java/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }


### PR DESCRIPTION
[Bintray and JCenter are now deprecated and becoming read-only](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), so it is not recommended to use it in examples any more. Replace usage of JCenter with Maven Central instead.